### PR TITLE
ft: Refactor `SnippetSerializer` to use `ModelSerializer`

### DIFF
--- a/tutorial/snippets/serializers.py
+++ b/tutorial/snippets/serializers.py
@@ -3,31 +3,7 @@ from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 
 
 class SnippetSerializer(serializers.Serializer):
-    id = serializers.IntegerField(read_only=True)
-    title = serializers.CharField(
-            required=False, allow_blank=True,
-            max_length=100)
-    code = serializers.CharField(style={'base_template': 'textarea.html'})
-    linenos = serializers.BooleanField(required=False)
-    language = serializers.ChoiceField(
-            choices=LANGUAGE_CHOICES, default='python')
-    style = serializers.ChoiceField(choices=STYLE_CHOICES, default='friendly')
 
-    def create(self, validated_data):
-        """
-        Create and return a new `Snippet` instance given the validated data
-        """
-        return Snippet.objects.create(**validated_data)
-
-    def update(self, instance, validated_data):
-        """
-        Update and return an existing `Snippet` instance, given the validated
-        data.
-        """
-        instance.title = validated_data.get('title', instance.title)
-        instance.code = validated_data.get('code', instance.code)
-        instance.linenos = validated_data.get('linenos', instance.linenos)
-        instance.language = validated_data.get('language', instance.language)
-        instance.style = validated_data.get('style', instance.style)
-        instance.save()
-        return instance
+    class Meta:
+        model = Snippet
+        fields = ('id', 'title', 'code', 'linenos', 'language', 'style')


### PR DESCRIPTION
Refactored `SnippetSerializer to use `ModelSerializer` to minimize replication of information already in the `Snippet` model and to have standard implementations of `create` and `update` methods.