### PR TITLE
ft: Add format suffix

### DIFF
--- a/tutorial/snippets/urls.py
+++ b/tutorial/snippets/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
 
+from rest_framework.urlpatterns import format_suffix_patterns
+
 from snippets import views
 
 
@@ -7,3 +9,5 @@ urlpatterns = [
     path('snippets/', views.snippet_list),
     path('snippets/<int:pk>/', views.snippet_detail),
 ]
+
+urlpatterns = format_suffix_patterns(urlpatterns)

--- a/tutorial/snippets/views.py
+++ b/tutorial/snippets/views.py
@@ -7,7 +7,7 @@ from snippets.serializers import SnippetSerializer
 
 
 @api_view(['GET', 'POST'])
-def snippet_list(request):
+def snippet_list(request, format=None):
     """
     List all code snippets, or create a new snippet
     """
@@ -25,7 +25,7 @@ def snippet_list(request):
 
 
 @api_view(['GET', 'PUT', 'DELETE'])
-def snippet_detail(request, pk):
+def snippet_detail(request, pk, format=None):
     """
     Retrieve, update or delete a code snippet.
     """

--- a/tutorial/tutorial/settings.py
+++ b/tutorial/tutorial/settings.py
@@ -120,3 +120,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+REST_FRAMEWORK= {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10
+}


### PR DESCRIPTION
Added format suffixes to API endpoints in views module to take advantage of having responses that are not hardwired to a single content type.