### PR TITLE
Add custom `perform_create()` method

### DIFF
--- a/tutorial/snippets/views.py
+++ b/tutorial/snippets/views.py
@@ -14,6 +14,9 @@ class SnippetList(generics.ListCreateAPIView):
     queryset = Snippet.objects.all()
     serializer_class = SnippetSerializer
 
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)
+
 
 class SnippetDetail((generics.RetrieveUpdateDestroyAPIView)):
     """


### PR DESCRIPTION
Added custom `perform_create()` method to the snippet views that allows modification of how the instance save is managed and handle any information that is implicit in the incoming request or requested URL.