### PR TITLE
Update serializer

### DIFF
--- a/tutorial/snippets/serializers.py
+++ b/tutorial/snippets/serializers.py
@@ -7,9 +7,13 @@ from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 
 class SnippetSerializer(serializers.Serializer):
 
+    owner = serializers.ReadOnlyField(source='owner.username')
+
     class Meta:
         model = Snippet
-        fields = ('id', 'title', 'code', 'linenos', 'language', 'style')
+        fields = ('id', 'title', 'code',
+                 'linenos', 'language', 'style',
+                 'owner')
 
 
 class UserSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Updated serializer to reflect association with the user that created them.

The `source` argument controls which attribute is used to populate a field, and can point an any attribute on the serialized instance.

Using the dotted notation, it will traverse the given attributes.

`ReadOnlyField` is always read-only and will be used for serialized representations not updating model instances when they are deserialized.

`CharField(read_only=True)` can also be used instead.