### PR TITLE
Add a pattern to include the login and logout views

### DIFF
--- a/tutorial/tutorial/urls.py
+++ b/tutorial/tutorial/urls.py
@@ -20,3 +20,7 @@ urlpatterns = [
     path('', include('snippets.urls')),
     path('admin/', admin.site.urls),
 ]
+
+urlpatterns += [
+    path('api-auth/', include('rest_framework.urls')),
+]


### PR DESCRIPTION
Added a pattern to include the login and logout views for the browsable API.

NB: the `api-auth` part can be whichever URL you would like to use.