### PR TITLE
Add object level permissions

### DIFF
--- a/tutorial/snippets/permissions.py
+++ b/tutorial/snippets/permissions.py
@@ -1,0 +1,19 @@
+from rest_framework import permissions
+
+
+class IsOwnerOrReadOnly(permissions.BasePermission):
+    """
+    Custom permission to only allow owners of an object
+    to edit it
+    """
+
+    def has_object_permissions(self, request, view, obj):
+        # Read permissions are allowed to any request
+        # so we'll always allow GET, HEAD or OPTIONS
+        # requests
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # Write permissions are only allowed to the owner
+        # of the snippet
+        return obj.owner == request.user

--- a/tutorial/snippets/views.py
+++ b/tutorial/snippets/views.py
@@ -4,6 +4,7 @@ from rest_framework import generics
 frome rest_framework import permissions
 
 from snippets.models import Snippet
+from snippets.permissions import IsOwnerOrReadOnly
 from snippets.serializers import SnippetSerializer
 from snippets.serializers import UserSerializer
 
@@ -14,7 +15,8 @@ class SnippetList(generics.ListCreateAPIView):
     """
     queryset = Snippet.objects.all()
     serializer_class = SnippetSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly,
+                          IsOwnerOrReadOnly]
 
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)


### PR DESCRIPTION
Added a custom permission in `snippets.permissions` module that allows code snippets to be visible to
anyone but only the user that created a code snippet is able to update or delete it.

Added the permissions to the `snippets.views` module.