### PR TITLE
Add endpoint for root of API

### DIFF
--- a/tutorial/snippets/views.py
+++ b/tutorial/snippets/views.py
@@ -2,11 +2,22 @@ from django.contrib.auth.models import User
 
 from rest_framework import generics
 frome rest_framework import permissions
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
 from snippets.models import Snippet
 from snippets.permissions import IsOwnerOrReadOnly
 from snippets.serializers import SnippetSerializer
 from snippets.serializers import UserSerializer
+
+
+@api_view(['GET'])
+def api_root(request, format=None):
+    return Response({
+        'users': reverse('user-list', request=request, format=format),
+        'snippets': reverse('snippet-list', request=request, format=format)
+    })
 
 
 class SnippetList(generics.ListCreateAPIView):


### PR DESCRIPTION
Added an endpoint for the root of the API.
We use the `reverse` function from the REST framework in order to return fully-qualified URLs. The URL patterns are identified by convenience names that will be used in the `snippets.urls` module.