### PR TITLE
Modify serializers to extend `HyperlinkedModelSerializer`

### DIFF
--- a/tutorial/snippets/serializers.py
+++ b/tutorial/snippets/serializers.py
@@ -5,21 +5,22 @@ from rest_framework import serializers
 from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 
 
-class SnippetSerializer(serializers.Serializer):
+class SnippetSerializer(serializers.HyperlinkedModelSerializer):
 
     owner = serializers.ReadOnlyField(source='owner.username')
+    highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')
 
     class Meta:
         model = Snippet
-        fields = ('id', 'title', 'code',
-                 'linenos', 'language', 'style',
-                 'owner')
+        fields = ('url', 'id', 'highlight',
+                'title', 'code', 'linenos',
+                'language', 'style', 'owner')
 
 
 class UserSerializer(serializers.ModelSerializer):
-    snippets = serializers.PrimaryKeyRelatedField(
-            many=True, queryset=Snippet.objects.all())
+    snippets = serializers.HyperlinkedRelatedField(
+            many=True, view_name='snippet-detail', read_only=True)
 
     class Meta:
         model = User
-        fields = ['id', 'username', 'snippets']
+        fields = ['url', 'id', 'username', 'snippets']


### PR DESCRIPTION
Modified serializers to extend `HyperlinkedModelSerializer` instead of the previous `ModelSerializer`.

`HyperlinkedModelSerializer` differs from `ModelSerializer` in that it does not include the `id` field by default, it includes the `url` field (using `HyperlinkedIdentityField`) and relationships use the `HyperlinkedIdentityField` instead of `PrimaryKeyRelatedField`.

Added `highlight` field which is the same type as the `url` field except that it points to the `snippet-highlight` url pattern instead of `snippet-detail` url pattern.

We indicate on the `highlight` field that any format suffixed hyperlinks it returns should use `.html` suffix.