### PR TITLE
Add names referencing hyperlined API to `urlpatterns`

### DIFF
--- a/tutorial/snippets/urls.py
+++ b/tutorial/snippets/urls.py
@@ -5,13 +5,17 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from snippets import views
 
 
-urlpatterns = [
+urlpatterns = format_suffix_patterns([
     path('', views.api_root),
-    path('snippets/', views.SnippetList.as_view()),
-    path('snippets/<int:pk>/', views.SnippetDetail.as_view()),
-    path('snippets/<int:pk>/highlight/', views.SnippetHighlight.as_view()),
+    path('snippets/',
+         views.SnippetList.as_view(),
+         name='snippet-list'),
+    path('snippets/<int:pk>/',
+         views.SnippetDetail.as_view(),
+         name='snippet-list'),
+    path('snippets/<int:pk>/highlight/',
+         views.SnippetHighlight.as_view(),
+         name='snippet-highlight'),
     path('users/', views.UserList.as_view()),
     path('users/<int:pk>/', views.UserDetail.as_view()),
-]
-
-urlpatterns = format_suffix_patterns(urlpatterns)
+)]


### PR DESCRIPTION
Added names referencing hyperlined API to `urlpatterns`.