### PR TITLE
Refactor views to use ViewSets

### DIFF
--- a/tutorial/snippets/views.py
+++ b/tutorial/snippets/views.py
@@ -1,11 +1,8 @@
 from django.contrib.auth.models import User
 
-from rest_framework import generics
-from rest_framework import permissions
-from rest_framework import renderers
-from rest_framework.decorators import api_view
+from rest_framework import permissions, renderers, viewsets
+from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 
 from snippets.models import Snippet
 from snippets.permissions import IsOwnerOrReadOnly
@@ -13,49 +10,31 @@ from snippets.serializers import SnippetSerializer
 from snippets.serializers import UserSerializer
 
 
-@api_view(['GET'])
-def api_root(request, format=None):
-    return Response({
-        'users': reverse('user-list', request=request, format=format),
-        'snippets': reverse('snippet-list', request=request, format=format)
-    })
-
-
-class SnippetList(generics.ListCreateAPIView):
+class SnippetViewSet(viewsets.ModelViewSet):
     """
-    List all code snippets, or create a new snippet
+    This viewset automatically provides `list`, `create`, `retrieve`,
+    `update` and `destroy` actions.
+
+    Additionally we also provide an extra `highlight` action.
     """
     queryset = Snippet.objects.all()
     serializer_class = SnippetSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly,
                           IsOwnerOrReadOnly]
 
+    @action(detail=True, renderer_classes=[renderers.StaticHTMLRenderer])
+    def highlight(self, request, *args, **kwargs)
+        snippet = self.get_object()
+        return Response(snippet.highlighted)
+
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
 
 
-class SnippetDetail((generics.RetrieveUpdateDestroyAPIView)):
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    Retrieve, update or delete a code snippet.
+    This viewset automatically provides `list` and `detail` actions
     """
-    queryset = Snippet.objects.all()
-    serializer_class = SnippetSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-
-    def get(self, request, *args, **kwargs):
-        snippet = self.get_object()
-        return Response(snippet.highlighted)
-
-class SnippetHighlight(generics.GenericAPIView):
-    queryset = Snippet.objects.all()
-    renderer_classes = [renderers.StaticHTMLRenderer]
-
-
-class UserList(generics.ListAPIView):
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
-
-class UserDetail(generics.RetrieveAPIView):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer


### PR DESCRIPTION
Refactored the user related views into one `UserViewSet`. We used the `ReadOnlyModelViewSet` class to automatically provide the default read-only operations.

Refactored the snippet related views into one `SnippetViewSet`. We used the `ModelViewSet` in order to get the complete set of default read and write operations.

We used the `@action` decorator to create a custom action named `highlight`. This decorator can be used to add any custom endpoints that don't fit into the standard `create`/`update`/
`delete` style.

Custom actions which use the `@action` decorator will respond to `GET` requests by default. The `methods` argument is used if we want an action that responds to `POST` requests.

URLs for custom actions by default depend on the method name itself. To change the way the url should be constructed, we can include `url_path` as a decorator keyword argument.