### PR TITLE
ft Bind viewsets to URLs explicitly

### DIFF
--- a/tutorial/snippets/urls.py
+++ b/tutorial/snippets/urls.py
@@ -1,21 +1,40 @@
 from django.urls import path
 
+from rest_framework import renderers
 from rest_framework.urlpatterns import format_suffix_patterns
 
-from snippets import views
+from snippets.views import SnippetViewSet, UserViewSet, api_root
 
+
+snippet_list = SnippetViewSet.as_view({
+    'get': 'list',
+    'post': 'create'
+})
+
+snippet_detail = SnippetViewSet.as_view({
+    'get': 'retrieve',
+    'put': 'update',
+    'patch': 'partial_update',
+    'delete': 'destroy'
+})
+
+snippet_highlight = SnippetViewSet.as_view({
+    'get': 'highlight'
+}, renderer_classes=[renderers.StaticHTMLRenderer])
+
+user_list = UserViewSet.as_view({
+    'get': 'list'
+})
+
+user_detail = UserViewSet.as_view({
+    'get': 'retrieve'
+})
 
 urlpatterns = format_suffix_patterns([
-    path('', views.api_root),
-    path('snippets/',
-         views.SnippetList.as_view(),
-         name='snippet-list'),
-    path('snippets/<int:pk>/',
-         views.SnippetDetail.as_view(),
-         name='snippet-list'),
-    path('snippets/<int:pk>/highlight/',
-         views.SnippetHighlight.as_view(),
-         name='snippet-highlight'),
-    path('users/', views.UserList.as_view()),
-    path('users/<int:pk>/', views.UserDetail.as_view()),
-)]
+    path('', api_root),
+    path('snippets/', snippet_list, name='snippet-list'),
+    path('snippets/<int:pk>/', snippet_detail, name='snippet-detail'),
+    path('snippets/<int:pk>/highlight/', snippet_highlight, name='snippet-highlight'),
+    path('users/', user_list, name='user-list'),
+    path('users/<int:pk>', user_detail, name='user-detail'),
+])

--- a/tutorial/snippets/views.py
+++ b/tutorial/snippets/views.py
@@ -10,6 +10,20 @@ from snippets.serializers import SnippetSerializer
 from snippets.serializers import UserSerializer
 
 
+@api_view(['GET'])
+def api_root(request, format=None):
+    return Respnse({
+        'users': reverse(
+            'user-list', request=request,
+            format=format
+        ),
+        'snippets': reverse(
+            'snippet-list', request=request,
+            format=format
+        )
+    })
+
+
 class SnippetViewSet(viewsets.ModelViewSet):
     """
     This viewset automatically provides `list`, `create`, `retrieve`,


### PR DESCRIPTION
Make multiple views from each `ViewSet` class by binding the http methods to the required action for each view.

Register the views with URL conf.

