### PR TITLE
Use `Router` class to wire views and urls conventions

### DIFF
--- a/tutorial/snippets/urls.py
+++ b/tutorial/snippets/urls.py
@@ -1,40 +1,14 @@
-from django.urls import path
+from django.conf.urls import include, url
 
-from rest_framework import renderers
-from rest_framework.urlpatterns import format_suffix_patterns
+from rest_framework.routers import DefaultRouter
 
-from snippets.views import SnippetViewSet, UserViewSet, api_root
+from snippets import views
 
 
-snippet_list = SnippetViewSet.as_view({
-    'get': 'list',
-    'post': 'create'
-})
+router = DefaultRouter()
+router.register(r'snippets', views.SnippetViewSet)
+router.register(r'users', views.UserViewSet)
 
-snippet_detail = SnippetViewSet.as_view({
-    'get': 'retrieve',
-    'put': 'update',
-    'patch': 'partial_update',
-    'delete': 'destroy'
-})
-
-snippet_highlight = SnippetViewSet.as_view({
-    'get': 'highlight'
-}, renderer_classes=[renderers.StaticHTMLRenderer])
-
-user_list = UserViewSet.as_view({
-    'get': 'list'
-})
-
-user_detail = UserViewSet.as_view({
-    'get': 'retrieve'
-})
-
-urlpatterns = format_suffix_patterns([
-    path('', api_root),
-    path('snippets/', snippet_list, name='snippet-list'),
-    path('snippets/<int:pk>/', snippet_detail, name='snippet-detail'),
-    path('snippets/<int:pk>/highlight/', snippet_highlight, name='snippet-highlight'),
-    path('users/', user_list, name='user-list'),
-    path('users/<int:pk>', user_detail, name='user-detail'),
-])
+urlpatterns = [
+    path('', include(router.urls)),
+]


### PR DESCRIPTION
Refactored urls module to use the `Router` class by registering the appropriate view sets with the router

We provide two arguments - the URL prefix for the views, and the viewset itself.

The `DefaultRouter` class automatically creates the API root view for us, so we can now delete the `api_root` method from the `views` module.